### PR TITLE
Update nginx_ctf.conf to fix typo

### DIFF
--- a/nginx_ctf.conf
+++ b/nginx_ctf.conf
@@ -35,7 +35,7 @@ server {
             proxy_set_header Upgrade \$http_upgrade;
             proxy_set_header Connection 'upgrade';
             proxy_set_header Host \$host;
-            proxy_cache_bypass \$http_upgrade
+            proxy_cache_bypass \$http_upgrade;
         }
 
         location /api/submitFlag {


### PR DESCRIPTION
````
 ~/CTF_Cafe_platform   *  sudo nginx -t                                                                                                                                                            10.7s  Sat 15 Apr 2023 11:23:37 AM CEST
nginx: [emerg] unexpected "}" in /etc/nginx/sites-enabled/default:39
nginx: configuration file /etc/nginx/nginx.conf test failed
````